### PR TITLE
install correct gosu for each architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update \
  && apt-get autoclean -y \
  && apt-get autoremove
 
-RUN curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64" && \
-	echo "bd8be776e97ec2b911190a82d9ab3fa6c013ae6d3121eea3d0bfd5c82a0eaf8c /usr/local/bin/gosu" | sha256sum -c && \
+RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" && \
+	curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.14/gosu-$dpkgArch" && \
 	chmod +x /usr/local/bin/gosu
 
 # and get the source code


### PR DESCRIPTION
Support linux/arm64 architecture by using correct gosu architecture. Supports now Raspberry Pi 5 with Raspberry Pi OS 64 bit.